### PR TITLE
데이터 패치 방식 수정

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import { Header } from '@/components/Header';
 import { LineList } from '@/components/LineList';
+import { getLineInfo } from '@/services/lineInfo';
 import { Line } from '@/types/line';
-import axios from 'axios';
 import { GetStaticProps } from 'next';
 
 type HomePageProps = {
@@ -10,7 +10,8 @@ type HomePageProps = {
 
 export const getStaticProps: GetStaticProps = async () => {
   try {
-    const { data: lineInfo } = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/api/line`);
+    // const { data: lineInfo } = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/api/line`);
+    const lineInfo = await getLineInfo();
     return { props: { lineInfo: lineInfo } };
   } catch (error) {
     console.error('Error fetching line info:', error);

--- a/pages/line/[lineName].tsx
+++ b/pages/line/[lineName].tsx
@@ -1,8 +1,8 @@
 import { Header } from '@/components/Header';
 import Map from '@/components/Map';
 import useWebSocket from '@/hooks/useWebSocket';
+import { getLineByName } from '@/services/lineInfo';
 import { Line } from '@/types/line';
-import axios from 'axios';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
@@ -21,9 +21,10 @@ export const getStaticPaths: GetStaticPaths = () => {
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   try {
     if (params && typeof params.lineName === 'string') {
-      const { data: lineInfo } = await axios.get(
-        `${process.env.NEXT_PUBLIC_BASE_URL}/api/line/${params.lineName}`,
-      );
+      // const { data: lineInfo } = await axios.get(
+      //   `${process.env.NEXT_PUBLIC_BASE_URL}/api/line/${params.lineName}`,
+      // );
+      const lineInfo = await getLineByName(params.lineName);
       return { props: { lineInfo } };
     }
     return { props: { lineInfo: null } };


### PR DESCRIPTION
## 변경사항

- 데이터 패치 방식을 수정하여 `API Routes`를 사용하는 대신 `getStaticProps` 사용하도록 변경

## 변경이유

- `API Routes`와 `getStaticProps`를 동시에 사용했을 때 빌드 시 데이터 패치가 되지 않는 문제를 발견하여 `getStaticProps`만을 사용하도록 변경